### PR TITLE
@minimum_churn_count should be Fixnum

### DIFF
--- a/lib/churn/churn_calculator.rb
+++ b/lib/churn/churn_calculator.rb
@@ -24,7 +24,7 @@ module Churn
     # intialized the churn calculator object
     def initialize(options={})
       start_date = options.fetch(:start_date) { '3 months ago' }
-      @minimum_churn_count = options.fetch(:minimum_churn_count) { 5 }
+      @minimum_churn_count = options.fetch(:minimum_churn_count) { 5 }.to_i
       @ignore_files     = (options.fetch(:ignore_files){ "" }).split(',').map(&:strip)
       @ignore_files << '/dev/null'
       @source_control   = set_source_control(start_date)

--- a/test/unit/churn_calculator_test.rb
+++ b/test/unit/churn_calculator_test.rb
@@ -16,6 +16,15 @@ class ChurnCalculatorTest < Test::Unit::TestCase
     end
   end
 
+  should "ensure that minimum churn count is initialized as a Fixnum" do
+    within_construct do |container|
+      Churn::ChurnCalculator.stubs(:git?).returns(true)
+      churn = Churn::ChurnCalculator.new({:minimum_churn_count => "3"})
+
+      assert_equal 3, churn.instance_variable_get(:@minimum_churn_count)
+    end
+  end
+
   should "use ignore_files filter" do
     within_construct do |container|
       Churn::ChurnCalculator.stubs(:git?).returns(true)


### PR DESCRIPTION
When we installed this gem and set up ENV['CHURN_MINIMUM_CHURN_COUNT'] = 1, we got this error when running 'rake churn': "comparison of String to Fixnum failed"

To fix this we updated ChurnCalculator's initialize method to ensure @minimum_churn_count gets initialized as a Fixnum and not a String.

We also added a test to cover this case.
