### PR TITLE
Send params only for set environment variables.

### DIFF
--- a/lib/tasks/churn_tasks.rb
+++ b/lib/tasks/churn_tasks.rb
@@ -1,10 +1,11 @@
 def report_churn()
   require File.join(File.dirname(__FILE__), '..', 'churn', 'churn_calculator')
-  Churn::ChurnCalculator.new({
-                               :minimum_churn_count => ENV['CHURN_MINIMUM_CHURN_COUNT'],
-                               :start_date => ENV['CHURN_START_DATE'],
-                               :ignore_files => ENV['CHURN_IGNORE_FILES'],
-                             }).report
+  params = {}
+  { :minimum_churn_count => ENV['CHURN_MINIMUM_CHURN_COUNT'],
+    :start_date          => ENV['CHURN_START_DATE'],
+    :ignore_files        => ENV['CHURN_IGNORE_FILES'],
+  }.each {|k,v| params[k] = v unless v.nil? }
+  Churn::ChurnCalculator.new(params).report
 end
 
 desc "Report the current churn for the project"
@@ -12,4 +13,3 @@ task :churn do
   report = report_churn()
   puts report
 end
-


### PR DESCRIPTION
Given ENV['CHURN_IGNORE_FILES'] is empty
Then :ignore_files will be provided with nil.
And options.fetch(:ignore_files) { "" } => nil

This breaks `@ignore_files = (options.fetch(:ignore_files){ "" }).split(',').map(&:strip)` in churn_calculator's initializer, with nil.split.
