### PR TITLE
Remove unnecessary check

### DIFF
--- a/lib/churn/history.rb
+++ b/lib/churn/history.rb
@@ -4,12 +4,12 @@ module Churn
   # and for loading old churn history data from json.
   class ChurnHistory
 
-    #takes current revision and it's hash_data and stores it
+    #takes current revision and its hash_data and stores it
     def self.store_revision_history(revision, hash_data)
-      FileUtils.mkdir_p tmp_churn_directory unless File.directory?(tmp_churn_directory)
+      FileUtils.mkdir_p tmp_churn_directory
       File.open("#{tmp_churn_directory}/#{revision}.json", 'w') {|file| file.write(hash_data.to_json) }
     end
-    
+
     #given a previous project revision find and load the churn data from a json file
     def self.load_revision_data(revision)
       #load revision data from scratch folder if it exists


### PR DESCRIPTION
Just something I noticed while looking at the code :smile:

`mkdir_p` already checks for the directories existence. [For reference.](http://ruby-doc.org/stdlib-1.9.3/libdoc/fileutils/rdoc/FileUtils.html#method-c-mkdir_p)
