### PR TITLE
Remove debug puts statement from bin/churn script

### DIFF
--- a/bin/churn
+++ b/bin/churn
@@ -4,7 +4,6 @@ require "pathname"
 bin_file = Pathname.new(__FILE__).realpath
 
 # add self to libpath
-puts File.expand_path("../../lib", bin_file)
 $:.unshift File.expand_path("../../lib", bin_file)
 
 require 'churn/calculator'


### PR DESCRIPTION
Churn has a debug puts statement in `bin/churn` which breaks file formatting when exporting
metrics in YAML. This PR removes that debug line. 
