### PR TITLE
Travis: jruby-9.1.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
       gemfile: gemfiles/Gemfile.2_3
     - rvm: jruby-19mode
       gemfile: gemfiles/Gemfile.jruby-19mode
-    - rvm: jruby-9.1.10.0
+    - rvm: jruby-9.1.12.0
       gemfile: gemfiles/Gemfile.jruby-9_1_5_0
       env:
         - JRUBY_OPTS='--debug'


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/06/15/jruby-9-1-12-0.html