### PR TITLE
Path prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ churn -y                            # Output yaml format opposed to text
 churn -c 10                         # Set minimum churn count on a file to 10
 churn -c 5 -y -i "Gemfile"          # Mix and match
 churn -e rb                         # Specify a file extension. The dot will be prepended automatically ("rb" -> ".rb") 
+churn -f app                        # Specify a file prefix, e.g. app/models
 churn --start_date "6 months ago"   # Start looking at file changes from 6 months ago
 churn -p "4 months ago"             # Churn the past history to build up data for the last 4 months
 churn --past_history                # Churn the past history for default 3 months to build up data
@@ -138,6 +139,7 @@ Methods:
       int(minimum_churn_count=3))
       --yaml, -y
       --extension, -e (0 ~> string(file_extension=))
+      --prefix, -f (0 ~> string(file_prefix=))
       --ignore_files=[ignore_files], -i (0 ~> string(ignore_files=))
       --start_date=[start_date], -s (0 ~> string(start_date=))
       --data_directory=[data_directory], -d (0 ~> string(data_directory=))
@@ -156,6 +158,7 @@ All the CLI options are parsed and just passed into the library. If you want to 
 options = {:minimum_churn_count => params['minimum_churn_count'].value,
   :ignore_files => params['ignore_files'].value,
   :file_extension => params['file_extension'].value,
+  :file_prefix => params['file_prefix'].value,
   :start_date => params['start_date'].value,
   :data_directory => params['data_directory'].value,
   :history => params['past_history'].value,

--- a/bin/churn
+++ b/bin/churn
@@ -67,6 +67,12 @@ Main do
     default ''
   end
 
+  option('prefix', 'f') do
+    cast :string
+    argument :optional
+    default ''
+  end
+
   def report_churn(output_string)
     options = {
       minimum_churn_count: params['minimum_churn_count'].value,
@@ -76,7 +82,8 @@ Main do
       history: params['past_history'].value,
       report: params['report'].value,
       name: params['name'].value,
-      file_extension: params['extension'].value
+      file_extension: params['extension'].value,
+      file_prefix: params['prefix'].value
     }
     result = Churn::ChurnCalculator.new(options).report(output_string)
     if output_string

--- a/lib/churn/calculator.rb
+++ b/lib/churn/calculator.rb
@@ -89,7 +89,7 @@ module Churn
     # on the edited files
     def analyze
       @changes = sort_changes(@changes)
-      @changes = filter_changes(@changes) if @churn_options.file_extension && !@churn_options.file_extension.empty?
+      @changes = filter_changes(@changes)
       @changes = @changes.map {|file_path, times_changed| {:file_path => file_path, :times_changed => times_changed }}
 
       calculate_revision_changes
@@ -159,7 +159,15 @@ module Churn
     end
 
     def filter_changes(changes)
-      changes.select { |file_path, _revision_count| file_path =~ /\.#{@churn_options.file_extension}\z/ }
+      if @churn_options.file_extension && !@churn_options.file_extension.empty?
+        changes = changes.select { |file_path, _revision_count| file_path =~ /\.#{@churn_options.file_extension}\z/ }
+      end
+
+      if @churn_options.file_prefix && !@churn_options.file_prefix.empty?
+        changes = changes.select! { |file_path, _revision_count| file_path =~ /\A#{@churn_options.file_prefix}/ }
+      end
+
+      changes
     end
 
     def filters

--- a/lib/churn/options.rb
+++ b/lib/churn/options.rb
@@ -9,7 +9,7 @@ module Churn
     DEFAULT_START_TIME = '3 months ago'
     DEFAULT_REPORT_HOST = 'http://churn.picoappz.com'
 
-    attr_accessor :data_directory, :minimum_churn_count, :ignores, :start_date, :history, :report_host, :name, :file_extension
+    attr_accessor :data_directory, :minimum_churn_count, :ignores, :start_date, :history, :report_host, :name, :file_extension, :file_prefix
     
     def initialize()
       @data_directory      = DEFAULT_CHURN_DIRECTORY
@@ -20,11 +20,13 @@ module Churn
       @report_host         = nil
       @name                = nil
       @file_extension      = nil
+      @file_prefix         = nil
     end
 
     def set_options(options = {})
       @data_directory      = options.fetch(:data_directory){ @data_directory } unless options[:data_directory]==''
       @file_extension      = options.fetch(:file_extension){ @file_extension } unless options[:file_extension]==''
+      @file_prefix      = options.fetch(:file_prefix){ @file_prefix } unless options[:file_prefix]==''
       @minimum_churn_count = options.fetch(:minimum_churn_count){ @minimum_churn_count }.to_i
       @ignores             = (options.fetch(:ignores){ @ignores }).to_s.split(',').map(&:strip)
       @ignores << '/dev/null' unless @ignores.include?('/dev/null')

--- a/test/unit/churn_options_test.rb
+++ b/test/unit/churn_options_test.rb
@@ -19,4 +19,9 @@ class ChurnOptionsTest < Minitest::Test
     assert_equal 'rb', options.file_extension
   end
 
+  should "set the file prefix" do
+    options = Churn::ChurnOptions.new
+    options.set_options({:file_prefix => 'app/'})
+    assert_equal 'app/', options.file_prefix
+  end
 end


### PR DESCRIPTION
This PR adds the possibility to specify a file prefix (like `app/models`) via a Churn::ChurnOptions attribute.