### PR TITLE
Add require 'churn/version' to support `churn --version`

### DIFF
--- a/bin/churn
+++ b/bin/churn
@@ -7,6 +7,7 @@ bin_file = Pathname.new(__FILE__).realpath
 $:.unshift File.expand_path("../../lib", bin_file)
 
 require 'churn/calculator'
+require 'churn/version'
 require 'main'
 require 'yaml'
 


### PR DESCRIPTION
Hey @danmayer,

This fixes a problem I found while testing #81.

Please check it out.

Thanks! 