### PR TITLE
Test with more modern rubies, bump runtime/development dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, truffleruby, truffleruby-head]
+        ruby: ["2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "truffleruby", "truffleruby-head"]
     runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        ruby: ["2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "truffleruby", "truffleruby-head"]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3", "truffleruby", "truffleruby-head"]
     runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/checkout@v2

--- a/churn.gemspec
+++ b/churn.gemspec
@@ -23,16 +23,16 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "main", ">= 0"
   # TODO: How to replace chronic, or just have less verbose time support
   s.add_runtime_dependency "chronic", ">= 0.2.3"
-  s.add_runtime_dependency "sexp_processor", "~> 4.1"
+  s.add_runtime_dependency "sexp_processor", "~> 4.17"
   s.add_runtime_dependency "ruby_parser", "~> 3.0"
   # TODO: Just have clean output and drop hirb
   s.add_runtime_dependency "hirb", ">= 0"
 
   s.add_development_dependency 'pry-byebug'
-  s.add_development_dependency "minitest", "~> 5.3"
+  s.add_development_dependency "minitest", "~> 5.22"
   s.add_development_dependency "test_construct", "~> 2.0.0"
   s.add_development_dependency "rake", ">= 0"
-  s.add_development_dependency "mocha", "~> 1.1.0"
+  s.add_development_dependency "mocha", "~> 2.1.0"
   s.add_development_dependency "simplecov", ">= 0"
   s.add_development_dependency "yard", "~> 0.9.20"
   # NOTE: we haven't been updating the man file, and ronn was used to do that... clean up

--- a/lib/churn/location_mapping.rb
+++ b/lib/churn/location_mapping.rb
@@ -30,7 +30,7 @@ module Churn
       start_line     = exp.line
       last_line      = deep_last_line(exp)
       name           = name if name.is_a?(Symbol)
-      name           = name.values.value if name.is_a?(Sexp) #deals with cases like class Test::Unit::TestCase
+      name           = name.to_a.last if name.is_a?(Sexp) #deals with cases like class Test::Unit::TestCase
       @current_class = name
       @klasses_collection[name.to_s] = [] unless @klasses_collection.include?(name)
       @klasses_collection[name.to_s] << (start_line..last_line)

--- a/test/data/test_helper.rb
+++ b/test/data/test_helper.rb
@@ -2,7 +2,7 @@ require 'rubygems'
 require 'minitest/autorun'
 require 'shoulda'
 require 'test_construct'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,7 @@ require 'simplecov'
 require 'minitest/autorun'
 #require 'shoulda'
 require 'test_construct'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 
 SimpleCov.start do
   add_filter 'specs/ruby/1.9.1/gems/'
@@ -14,7 +14,7 @@ end
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'churn/calculator'
-Mocha::Configuration.prevent(:stubbing_non_existent_method)
+# Mocha::Configuration.prevent(:stubbing_non_existent_method)
 
 class Minitest::Test
   include TestConstruct::Helpers

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,7 +14,6 @@ end
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'churn/calculator'
-# Mocha::Configuration.prevent(:stubbing_non_existent_method)
 
 class Minitest::Test
   include TestConstruct::Helpers


### PR DESCRIPTION
Hi @danmayer, thanks for maintaining `churn`! ❤️ 

I was wondering if `churn` would work fine with more modern rubies, so I decided to go ahead and configure GitHub Actions to test with more rubies:

- "3.0"
- "3.1"
- "3.2"

Please check it out and let me know what you think.

Thanks,
Ernesto